### PR TITLE
open_by_handle_at returns a file descriptor

### DIFF
--- a/src/linux_call.rs
+++ b/src/linux_call.rs
@@ -1195,11 +1195,11 @@ pub fn open_by_handle_at(
     mount_fd: i32,
     handle: &mut file_handle_t,
     flags: i32,
-) -> Result<(), Errno> {
+) -> Result<i32, Errno> {
     let mount_fd = mount_fd as usize;
     let handle_ptr = handle as *mut file_handle_t as usize;
     let flags = flags as usize;
-    syscall3(SYS_OPEN_BY_HANDLE_AT, mount_fd, handle_ptr, flags).map(drop)
+    syscall3(SYS_OPEN_BY_HANDLE_AT, mount_fd, handle_ptr, flags).map(|ret| ret as i32)
 }
 
 /// Open and possibly create a file within a directory.

--- a/src/platform/linux-aarch64/call.rs
+++ b/src/platform/linux-aarch64/call.rs
@@ -1665,11 +1665,11 @@ pub fn open_by_handle_at(
     mount_fd: i32,
     handle: &mut file_handle_t,
     flags: i32,
-) -> Result<(), Errno> {
+) -> Result<i32, Errno> {
     let mount_fd = mount_fd as usize;
     let handle_ptr = handle as *mut file_handle_t as usize;
     let flags = flags as usize;
-    syscall3(SYS_OPEN_BY_HANDLE_AT, mount_fd, handle_ptr, flags).map(drop)
+    syscall3(SYS_OPEN_BY_HANDLE_AT, mount_fd, handle_ptr, flags).map(|ret| ret as i32)
 }
 
 pub fn open_tree(dfd: i32, filename: &str, flags: u32) -> Result<i32, Errno> {

--- a/src/platform/linux-arm/call.rs
+++ b/src/platform/linux-arm/call.rs
@@ -1963,11 +1963,11 @@ pub fn open_by_handle_at(
     mount_fd: i32,
     handle: &mut file_handle_t,
     flags: i32,
-) -> Result<(), Errno> {
+) -> Result<i32, Errno> {
     let mount_fd = mount_fd as usize;
     let handle_ptr = handle as *mut file_handle_t as usize;
     let flags = flags as usize;
-    syscall3(SYS_OPEN_BY_HANDLE_AT, mount_fd, handle_ptr, flags).map(drop)
+    syscall3(SYS_OPEN_BY_HANDLE_AT, mount_fd, handle_ptr, flags).map(|ret| ret as i32)
 }
 
 pub fn open_tree(dfd: i32, filename: &str, flags: u32) -> Result<i32, Errno> {

--- a/src/platform/linux-mips/call.rs
+++ b/src/platform/linux-mips/call.rs
@@ -2012,11 +2012,11 @@ pub fn open_by_handle_at(
     mount_fd: i32,
     handle: &mut file_handle_t,
     flags: i32,
-) -> Result<(), Errno> {
+) -> Result<i32, Errno> {
     let mount_fd = mount_fd as usize;
     let handle_ptr = handle as *mut file_handle_t as usize;
     let flags = flags as usize;
-    syscall3(SYS_OPEN_BY_HANDLE_AT, mount_fd, handle_ptr, flags).map(drop)
+    syscall3(SYS_OPEN_BY_HANDLE_AT, mount_fd, handle_ptr, flags).map(|ret| ret as i32)
 }
 
 pub fn open_tree(dfd: i32, filename: &str, flags: u32) -> Result<i32, Errno> {

--- a/src/platform/linux-mips64/call.rs
+++ b/src/platform/linux-mips64/call.rs
@@ -1828,11 +1828,11 @@ pub fn open_by_handle_at(
     mount_fd: i32,
     handle: &mut file_handle_t,
     flags: i32,
-) -> Result<(), Errno> {
+) -> Result<i32, Errno> {
     let mount_fd = mount_fd as usize;
     let handle_ptr = handle as *mut file_handle_t as usize;
     let flags = flags as usize;
-    syscall3(SYS_OPEN_BY_HANDLE_AT, mount_fd, handle_ptr, flags).map(drop)
+    syscall3(SYS_OPEN_BY_HANDLE_AT, mount_fd, handle_ptr, flags).map(|ret| ret as i32)
 }
 
 pub fn open_tree(dfd: i32, filename: &str, flags: u32) -> Result<i32, Errno> {

--- a/src/platform/linux-ppc64/call.rs
+++ b/src/platform/linux-ppc64/call.rs
@@ -1968,11 +1968,11 @@ pub fn open_by_handle_at(
     mount_fd: i32,
     handle: &mut file_handle_t,
     flags: i32,
-) -> Result<(), Errno> {
+) -> Result<i32, Errno> {
     let mount_fd = mount_fd as usize;
     let handle_ptr = handle as *mut file_handle_t as usize;
     let flags = flags as usize;
-    syscall3(SYS_OPEN_BY_HANDLE_AT, mount_fd, handle_ptr, flags).map(drop)
+    syscall3(SYS_OPEN_BY_HANDLE_AT, mount_fd, handle_ptr, flags).map(|ret| ret as i32)
 }
 
 pub fn open_tree(dfd: i32, filename: &str, flags: u32) -> Result<i32, Errno> {

--- a/src/platform/linux-s390x/call.rs
+++ b/src/platform/linux-s390x/call.rs
@@ -1880,11 +1880,11 @@ pub fn open_by_handle_at(
     mount_fd: i32,
     handle: &mut file_handle_t,
     flags: i32,
-) -> Result<(), Errno> {
+) -> Result<i32, Errno> {
     let mount_fd = mount_fd as usize;
     let handle_ptr = handle as *mut file_handle_t as usize;
     let flags = flags as usize;
-    syscall3(SYS_OPEN_BY_HANDLE_AT, mount_fd, handle_ptr, flags).map(drop)
+    syscall3(SYS_OPEN_BY_HANDLE_AT, mount_fd, handle_ptr, flags).map(|ret| ret as i32)
 }
 
 pub fn open_tree(dfd: i32, filename: &str, flags: u32) -> Result<i32, Errno> {

--- a/src/platform/linux-x86/call.rs
+++ b/src/platform/linux-x86/call.rs
@@ -2100,11 +2100,11 @@ pub fn open_by_handle_at(
     mount_fd: i32,
     handle: &mut file_handle_t,
     flags: i32,
-) -> Result<(), Errno> {
+) -> Result<i32, Errno> {
     let mount_fd = mount_fd as usize;
     let handle_ptr = handle as *mut file_handle_t as usize;
     let flags = flags as usize;
-    syscall3(SYS_OPEN_BY_HANDLE_AT, mount_fd, handle_ptr, flags).map(drop)
+    syscall3(SYS_OPEN_BY_HANDLE_AT, mount_fd, handle_ptr, flags).map(|ret| ret as i32)
 }
 
 pub fn open_tree(dfd: i32, filename: &str, flags: u32) -> Result<i32, Errno> {

--- a/src/platform/linux-x86_64/call.rs
+++ b/src/platform/linux-x86_64/call.rs
@@ -1882,11 +1882,11 @@ pub fn open_by_handle_at(
     mount_fd: i32,
     handle: &mut file_handle_t,
     flags: i32,
-) -> Result<(), Errno> {
+) -> Result<i32, Errno> {
     let mount_fd = mount_fd as usize;
     let handle_ptr = handle as *mut file_handle_t as usize;
     let flags = flags as usize;
-    syscall3(SYS_OPEN_BY_HANDLE_AT, mount_fd, handle_ptr, flags).map(drop)
+    syscall3(SYS_OPEN_BY_HANDLE_AT, mount_fd, handle_ptr, flags).map(|ret| ret as i32)
 }
 
 pub fn open_tree(dfd: i32, filename: &str, flags: u32) -> Result<i32, Errno> {


### PR DESCRIPTION
As per manpage:

> On success, `name_to_handle_at()` returns 0, and `open_by_handle_at()` returns a file descriptor (a nonnegative integer).
