### PR TITLE
Fix some issues on arm target

### DIFF
--- a/src/platform/linux-types/arm/stat.rs
+++ b/src/platform/linux-types/arm/stat.rs
@@ -5,6 +5,7 @@
 pub const STAT_HAVE_NSEC: i32 = 0;
 
 #[repr(C)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct stat_t {
     pub st_dev: usize,
     pub st_ino: usize,
@@ -31,6 +32,7 @@ pub struct stat_t {
 /// Note: The kernel zero's the padded region because glibc might read them
 /// in the hope that the kernel has stretched to using larger sizes.
 #[repr(C)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct stat64_t {
     pub st_dev: u64,
     pad0: [u8; 4],

--- a/src/syscalls/syscall_arm.rs
+++ b/src/syscalls/syscall_arm.rs
@@ -8,7 +8,7 @@ use super::types::*;
 pub fn syscall0(n: Sysno) -> Result<usize, Errno> {
     let ret: usize;
     unsafe {
-        llvm_asm!("swi $$0"
+        llvm_asm!("swi 0"
          : "={r0}"(ret)
          : "{r7}"(n)
          : "memory" "cc"
@@ -21,7 +21,7 @@ pub fn syscall0(n: Sysno) -> Result<usize, Errno> {
 pub fn syscall1(n: Sysno, a1: usize) -> Result<usize, Errno> {
     let ret: usize;
     unsafe {
-        llvm_asm!("swi $$0"
+        llvm_asm!("swi 0"
          : "={r0}"(ret)
          : "{r7}"(n),
            "{r0}"(a1)
@@ -35,7 +35,7 @@ pub fn syscall1(n: Sysno, a1: usize) -> Result<usize, Errno> {
 pub fn syscall2(n: Sysno, a1: usize, a2: usize) -> Result<usize, Errno> {
     let ret: usize;
     unsafe {
-        llvm_asm!("swi $$0"
+        llvm_asm!("swi 0"
          : "={r0}"(ret)
          : "{r7}"(n),
            "{r0}"(a1),
@@ -50,7 +50,7 @@ pub fn syscall2(n: Sysno, a1: usize, a2: usize) -> Result<usize, Errno> {
 pub fn syscall3(n: Sysno, a1: usize, a2: usize, a3: usize) -> Result<usize, Errno> {
     let ret: usize;
     unsafe {
-        llvm_asm!("swi $$0"
+        llvm_asm!("swi 0"
          : "={r0}"(ret)
          : "{r7}"(n),
            "{r0}"(a1),
@@ -66,7 +66,7 @@ pub fn syscall3(n: Sysno, a1: usize, a2: usize, a3: usize) -> Result<usize, Errn
 pub fn syscall4(n: Sysno, a1: usize, a2: usize, a3: usize, a4: usize) -> Result<usize, Errno> {
     let ret: usize;
     unsafe {
-        llvm_asm!("swi $$0"
+        llvm_asm!("swi 0"
          : "={r0}"(ret)
          : "{r7}"(n),
            "{r0}"(a1),
@@ -90,7 +90,7 @@ pub fn syscall5(
 ) -> Result<usize, Errno> {
     let ret: usize;
     unsafe {
-        llvm_asm!("swi $$0"
+        llvm_asm!("swi 0"
          : "={r0}"(ret)
          : "{r7}"(n),
            "{r0}"(a1),
@@ -116,7 +116,7 @@ pub fn syscall6(
 ) -> Result<usize, Errno> {
     let ret: usize;
     unsafe {
-        llvm_asm!("swi $$0"
+        llvm_asm!("swi 0"
          : "={r0}"(ret)
          : "{r7}"(n),
            "{r0}"(a1),


### PR DESCRIPTION
Hi, I'm using nc in my project and it's great, but have run into some problems.

This PR fixes some problems when compiling with arm as the target.
- Wrong assembly code in `asm_llvm!`
- Add some default derive for `stat_t` and `stat64_t`