### PR TITLE
Fix rt_sigprocmask syscall parameters

### DIFF
--- a/src/linux_call.rs
+++ b/src/linux_call.rs
@@ -6358,11 +6358,11 @@ pub fn rt_sigpending(set: &mut [sigset_t]) -> Result<(), Errno> {
 }
 
 /// Change the list of currently blocked signals.
-pub fn rt_sigprocmask(how: i32, set: &sigset_t, oldset: &mut sigset_t) -> Result<(), Errno> {
+pub fn rt_sigprocmask(how: i32, set: &sigset_t, oldset: &mut sigset_t, sigsetsize: size_t) -> Result<(), Errno> {
     let how = how as usize;
     let set_ptr = set as *const sigset_t as usize;
     let oldset_ptr = oldset as *mut sigset_t as usize;
-    syscall3(SYS_RT_SIGPROCMASK, how, set_ptr, oldset_ptr).map(drop)
+    syscall4(SYS_RT_SIGPROCMASK, how, set_ptr, oldset_ptr, sigsetsize).map(drop)
 }
 
 /// Queue a signal and data.

--- a/src/platform/linux-aarch64/call.rs
+++ b/src/platform/linux-aarch64/call.rs
@@ -1205,6 +1205,7 @@ pub fn getdents64(fd: i32, dirp: usize, count: size_t) -> Result<ssize_t, Errno>
 /// assert!(egid > 0);
 /// ```
 pub fn getegid() -> gid_t {
+    // This function is always successful.
     syscall0(SYS_GETEGID).expect("getegid() failed") as gid_t
 }
 
@@ -1214,6 +1215,7 @@ pub fn getegid() -> gid_t {
 /// assert!(euid > 0);
 /// ```
 pub fn geteuid() -> uid_t {
+    // This function is always successful.
     syscall0(SYS_GETEUID).expect("geteuid() failed") as uid_t
 }
 
@@ -1223,6 +1225,7 @@ pub fn geteuid() -> uid_t {
 /// assert!(gid > 0);
 /// ```
 pub fn getgid() -> gid_t {
+    // This function is always successful.
     syscall0(SYS_GETGID).expect("getgid() failed") as gid_t
 }
 
@@ -1325,6 +1328,7 @@ pub fn getpgid(pid: pid_t) -> Result<pid_t, Errno> {
 /// assert!(pid > 0);
 /// ```
 pub fn getpid() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETPID).expect("getpid() failed") as pid_t
 }
 
@@ -1334,6 +1338,7 @@ pub fn getpid() -> pid_t {
 /// assert!(ppid > 0);
 /// ```
 pub fn getppid() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETPPID).expect("getppid() failed") as pid_t
 }
 
@@ -1441,6 +1446,7 @@ pub fn getrusage(who: i32, usage: &mut rusage_t) -> Result<(), Errno> {
 /// ```
 pub fn getsid(pid: pid_t) -> pid_t {
     let pid = pid as usize;
+    // This function is always successful.
     syscall1(SYS_GETSID, pid).expect("getsid() failed") as pid_t
 }
 
@@ -1486,6 +1492,7 @@ pub fn getsockopt(
 /// assert!(tid > 0);
 /// ```
 pub fn gettid() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETTID).expect("getpid() failed") as pid_t
 }
 
@@ -1509,6 +1516,7 @@ pub fn gettimeofday(timeval: &mut timeval_t, tz: &mut timezone_t) -> Result<(), 
 /// assert!(uid > 0);
 /// ```
 pub fn getuid() -> uid_t {
+    // This function is always successful.
     syscall0(SYS_GETUID).expect("getuid() failed") as uid_t
 }
 

--- a/src/platform/linux-aarch64/call.rs
+++ b/src/platform/linux-aarch64/call.rs
@@ -3956,11 +3956,16 @@ pub fn rt_sigpending(set: &mut [sigset_t]) -> Result<(), Errno> {
 }
 
 /// Change the list of currently blocked signals.
-pub fn rt_sigprocmask(how: i32, set: &sigset_t, oldset: &mut sigset_t) -> Result<(), Errno> {
+pub fn rt_sigprocmask(
+    how: i32,
+    set: &sigset_t,
+    oldset: &mut sigset_t,
+    sigsetsize: size_t,
+) -> Result<(), Errno> {
     let how = how as usize;
     let set_ptr = set as *const sigset_t as usize;
     let oldset_ptr = oldset as *mut sigset_t as usize;
-    syscall3(SYS_RT_SIGPROCMASK, how, set_ptr, oldset_ptr).map(drop)
+    syscall4(SYS_RT_SIGPROCMASK, how, set_ptr, oldset_ptr, sigsetsize).map(drop)
 }
 
 /// Queue a signal and data.

--- a/src/platform/linux-arm/call.rs
+++ b/src/platform/linux-arm/call.rs
@@ -4672,11 +4672,16 @@ pub fn rt_sigpending(set: &mut [sigset_t]) -> Result<(), Errno> {
 }
 
 /// Change the list of currently blocked signals.
-pub fn rt_sigprocmask(how: i32, set: &sigset_t, oldset: &mut sigset_t) -> Result<(), Errno> {
+pub fn rt_sigprocmask(
+    how: i32,
+    set: &sigset_t,
+    oldset: &mut sigset_t,
+    sigsetsize: size_t,
+) -> Result<(), Errno> {
     let how = how as usize;
     let set_ptr = set as *const sigset_t as usize;
     let oldset_ptr = oldset as *mut sigset_t as usize;
-    syscall3(SYS_RT_SIGPROCMASK, how, set_ptr, oldset_ptr).map(drop)
+    syscall4(SYS_RT_SIGPROCMASK, how, set_ptr, oldset_ptr, sigsetsize).map(drop)
 }
 
 /// Queue a signal and data.

--- a/src/platform/linux-arm/call.rs
+++ b/src/platform/linux-arm/call.rs
@@ -1569,6 +1569,7 @@ pub fn getdents64(fd: i32, dirp: usize, count: size_t) -> Result<ssize_t, Errno>
 /// assert!(egid > 0);
 /// ```
 pub fn getegid() -> gid_t {
+    // This function is always successful.
     syscall0(SYS_GETEGID).expect("getegid() failed") as gid_t
 }
 
@@ -1584,6 +1585,7 @@ pub fn getegid32() {
 /// assert!(euid > 0);
 /// ```
 pub fn geteuid() -> uid_t {
+    // This function is always successful.
     syscall0(SYS_GETEUID).expect("geteuid() failed") as uid_t
 }
 
@@ -1599,6 +1601,7 @@ pub fn geteuid32() {
 /// assert!(gid > 0);
 /// ```
 pub fn getgid() -> gid_t {
+    // This function is always successful.
     syscall0(SYS_GETGID).expect("getgid() failed") as gid_t
 }
 
@@ -1713,6 +1716,7 @@ pub fn getpgid(pid: pid_t) -> Result<pid_t, Errno> {
 /// assert!(pgroup > 0);
 /// ```
 pub fn getpgrp() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETPGRP).expect("getpgrp() failed") as pid_t
 }
 
@@ -1722,6 +1726,7 @@ pub fn getpgrp() -> pid_t {
 /// assert!(pid > 0);
 /// ```
 pub fn getpid() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETPID).expect("getpid() failed") as pid_t
 }
 
@@ -1731,6 +1736,7 @@ pub fn getpid() -> pid_t {
 /// assert!(ppid > 0);
 /// ```
 pub fn getppid() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETPPID).expect("getppid() failed") as pid_t
 }
 
@@ -1834,6 +1840,7 @@ pub fn getrusage(who: i32, usage: &mut rusage_t) -> Result<(), Errno> {
 /// ```
 pub fn getsid(pid: pid_t) -> pid_t {
     let pid = pid as usize;
+    // This function is always successful.
     syscall1(SYS_GETSID, pid).expect("getsid() failed") as pid_t
 }
 
@@ -1879,6 +1886,7 @@ pub fn getsockopt(
 /// assert!(tid > 0);
 /// ```
 pub fn gettid() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETTID).expect("getpid() failed") as pid_t
 }
 
@@ -1902,6 +1910,7 @@ pub fn gettimeofday(timeval: &mut timeval_t, tz: &mut timezone_t) -> Result<(), 
 /// assert!(uid > 0);
 /// ```
 pub fn getuid() -> uid_t {
+    // This function is always successful.
     syscall0(SYS_GETUID).expect("getuid() failed") as uid_t
 }
 

--- a/src/platform/linux-mips/call.rs
+++ b/src/platform/linux-mips/call.rs
@@ -125,6 +125,7 @@ pub fn afs_syscall() {
 /// ```
 pub fn alarm(seconds: u32) -> u32 {
     let seconds = seconds as usize;
+    // This function is always successful.
     syscall1(SYS_ALARM, seconds).expect("alarm() failed") as u32
 }
 
@@ -1627,6 +1628,7 @@ pub fn getdents64(fd: i32, dirp: usize, count: size_t) -> Result<ssize_t, Errno>
 /// assert!(egid > 0);
 /// ```
 pub fn getegid() -> gid_t {
+    // This function is always successful.
     syscall0(SYS_GETEGID).expect("getegid() failed") as gid_t
 }
 
@@ -1636,6 +1638,7 @@ pub fn getegid() -> gid_t {
 /// assert!(euid > 0);
 /// ```
 pub fn geteuid() -> uid_t {
+    // This function is always successful.
     syscall0(SYS_GETEUID).expect("geteuid() failed") as uid_t
 }
 
@@ -1645,6 +1648,7 @@ pub fn geteuid() -> uid_t {
 /// assert!(gid > 0);
 /// ```
 pub fn getgid() -> gid_t {
+    // This function is always successful.
     syscall0(SYS_GETGID).expect("getgid() failed") as gid_t
 }
 
@@ -1747,6 +1751,7 @@ pub fn getpgid(pid: pid_t) -> Result<pid_t, Errno> {
 /// assert!(pgroup > 0);
 /// ```
 pub fn getpgrp() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETPGRP).expect("getpgrp() failed") as pid_t
 }
 
@@ -1756,6 +1761,7 @@ pub fn getpgrp() -> pid_t {
 /// assert!(pid > 0);
 /// ```
 pub fn getpid() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETPID).expect("getpid() failed") as pid_t
 }
 
@@ -1770,6 +1776,7 @@ pub fn getpmsg() {
 /// assert!(ppid > 0);
 /// ```
 pub fn getppid() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETPPID).expect("getppid() failed") as pid_t
 }
 
@@ -1877,6 +1884,7 @@ pub fn getrusage(who: i32, usage: &mut rusage_t) -> Result<(), Errno> {
 /// ```
 pub fn getsid(pid: pid_t) -> pid_t {
     let pid = pid as usize;
+    // This function is always successful.
     syscall1(SYS_GETSID, pid).expect("getsid() failed") as pid_t
 }
 
@@ -1922,6 +1930,7 @@ pub fn getsockopt(
 /// assert!(tid > 0);
 /// ```
 pub fn gettid() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETTID).expect("getpid() failed") as pid_t
 }
 
@@ -1945,6 +1954,7 @@ pub fn gettimeofday(timeval: &mut timeval_t, tz: &mut timezone_t) -> Result<(), 
 /// assert!(uid > 0);
 /// ```
 pub fn getuid() -> uid_t {
+    // This function is always successful.
     syscall0(SYS_GETUID).expect("getuid() failed") as uid_t
 }
 

--- a/src/platform/linux-mips/call.rs
+++ b/src/platform/linux-mips/call.rs
@@ -4807,11 +4807,16 @@ pub fn rt_sigpending(set: &mut [sigset_t]) -> Result<(), Errno> {
 }
 
 /// Change the list of currently blocked signals.
-pub fn rt_sigprocmask(how: i32, set: &sigset_t, oldset: &mut sigset_t) -> Result<(), Errno> {
+pub fn rt_sigprocmask(
+    how: i32,
+    set: &sigset_t,
+    oldset: &mut sigset_t,
+    sigsetsize: size_t,
+) -> Result<(), Errno> {
     let how = how as usize;
     let set_ptr = set as *const sigset_t as usize;
     let oldset_ptr = oldset as *mut sigset_t as usize;
-    syscall3(SYS_RT_SIGPROCMASK, how, set_ptr, oldset_ptr).map(drop)
+    syscall4(SYS_RT_SIGPROCMASK, how, set_ptr, oldset_ptr, sigsetsize).map(drop)
 }
 
 /// Queue a signal and data.

--- a/src/platform/linux-mips64/call.rs
+++ b/src/platform/linux-mips64/call.rs
@@ -4481,11 +4481,16 @@ pub fn rt_sigpending(set: &mut [sigset_t]) -> Result<(), Errno> {
 }
 
 /// Change the list of currently blocked signals.
-pub fn rt_sigprocmask(how: i32, set: &sigset_t, oldset: &mut sigset_t) -> Result<(), Errno> {
+pub fn rt_sigprocmask(
+    how: i32,
+    set: &sigset_t,
+    oldset: &mut sigset_t,
+    sigsetsize: size_t,
+) -> Result<(), Errno> {
     let how = how as usize;
     let set_ptr = set as *const sigset_t as usize;
     let oldset_ptr = oldset as *mut sigset_t as usize;
-    syscall3(SYS_RT_SIGPROCMASK, how, set_ptr, oldset_ptr).map(drop)
+    syscall4(SYS_RT_SIGPROCMASK, how, set_ptr, oldset_ptr, sigsetsize).map(drop)
 }
 
 /// Queue a signal and data.

--- a/src/platform/linux-mips64/call.rs
+++ b/src/platform/linux-mips64/call.rs
@@ -125,6 +125,7 @@ pub fn afs_syscall() {
 /// ```
 pub fn alarm(seconds: u32) -> u32 {
     let seconds = seconds as usize;
+    // This function is always successful.
     syscall1(SYS_ALARM, seconds).expect("alarm() failed") as u32
 }
 
@@ -1475,6 +1476,7 @@ pub fn getdents64(fd: i32, dirp: usize, count: size_t) -> Result<ssize_t, Errno>
 /// assert!(egid > 0);
 /// ```
 pub fn getegid() -> gid_t {
+    // This function is always successful.
     syscall0(SYS_GETEGID).expect("getegid() failed") as gid_t
 }
 
@@ -1484,6 +1486,7 @@ pub fn getegid() -> gid_t {
 /// assert!(euid > 0);
 /// ```
 pub fn geteuid() -> uid_t {
+    // This function is always successful.
     syscall0(SYS_GETEUID).expect("geteuid() failed") as uid_t
 }
 
@@ -1493,6 +1496,7 @@ pub fn geteuid() -> uid_t {
 /// assert!(gid > 0);
 /// ```
 pub fn getgid() -> gid_t {
+    // This function is always successful.
     syscall0(SYS_GETGID).expect("getgid() failed") as gid_t
 }
 
@@ -1595,6 +1599,7 @@ pub fn getpgid(pid: pid_t) -> Result<pid_t, Errno> {
 /// assert!(pgroup > 0);
 /// ```
 pub fn getpgrp() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETPGRP).expect("getpgrp() failed") as pid_t
 }
 
@@ -1604,6 +1609,7 @@ pub fn getpgrp() -> pid_t {
 /// assert!(pid > 0);
 /// ```
 pub fn getpid() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETPID).expect("getpid() failed") as pid_t
 }
 
@@ -1618,6 +1624,7 @@ pub fn getpmsg() {
 /// assert!(ppid > 0);
 /// ```
 pub fn getppid() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETPPID).expect("getppid() failed") as pid_t
 }
 
@@ -1725,6 +1732,7 @@ pub fn getrusage(who: i32, usage: &mut rusage_t) -> Result<(), Errno> {
 /// ```
 pub fn getsid(pid: pid_t) -> pid_t {
     let pid = pid as usize;
+    // This function is always successful.
     syscall1(SYS_GETSID, pid).expect("getsid() failed") as pid_t
 }
 
@@ -1770,6 +1778,7 @@ pub fn getsockopt(
 /// assert!(tid > 0);
 /// ```
 pub fn gettid() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETTID).expect("getpid() failed") as pid_t
 }
 
@@ -1793,6 +1802,7 @@ pub fn gettimeofday(timeval: &mut timeval_t, tz: &mut timezone_t) -> Result<(), 
 /// assert!(uid > 0);
 /// ```
 pub fn getuid() -> uid_t {
+    // This function is always successful.
     syscall0(SYS_GETUID).expect("getuid() failed") as uid_t
 }
 

--- a/src/platform/linux-ppc64/call.rs
+++ b/src/platform/linux-ppc64/call.rs
@@ -125,6 +125,7 @@ pub fn afs_syscall() {
 /// ```
 pub fn alarm(seconds: u32) -> u32 {
     let seconds = seconds as usize;
+    // This function is always successful.
     syscall1(SYS_ALARM, seconds).expect("alarm() failed") as u32
 }
 
@@ -1507,6 +1508,7 @@ pub fn getdents64(fd: i32, dirp: usize, count: size_t) -> Result<ssize_t, Errno>
 /// assert!(egid > 0);
 /// ```
 pub fn getegid() -> gid_t {
+    // This function is always successful.
     syscall0(SYS_GETEGID).expect("getegid() failed") as gid_t
 }
 
@@ -1516,6 +1518,7 @@ pub fn getegid() -> gid_t {
 /// assert!(euid > 0);
 /// ```
 pub fn geteuid() -> uid_t {
+    // This function is always successful.
     syscall0(SYS_GETEUID).expect("geteuid() failed") as uid_t
 }
 
@@ -1525,6 +1528,7 @@ pub fn geteuid() -> uid_t {
 /// assert!(gid > 0);
 /// ```
 pub fn getgid() -> gid_t {
+    // This function is always successful.
     syscall0(SYS_GETGID).expect("getgid() failed") as gid_t
 }
 
@@ -1627,6 +1631,7 @@ pub fn getpgid(pid: pid_t) -> Result<pid_t, Errno> {
 /// assert!(pgroup > 0);
 /// ```
 pub fn getpgrp() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETPGRP).expect("getpgrp() failed") as pid_t
 }
 
@@ -1636,6 +1641,7 @@ pub fn getpgrp() -> pid_t {
 /// assert!(pid > 0);
 /// ```
 pub fn getpid() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETPID).expect("getpid() failed") as pid_t
 }
 
@@ -1650,6 +1656,7 @@ pub fn getpmsg() {
 /// assert!(ppid > 0);
 /// ```
 pub fn getppid() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETPPID).expect("getppid() failed") as pid_t
 }
 
@@ -1757,6 +1764,7 @@ pub fn getrusage(who: i32, usage: &mut rusage_t) -> Result<(), Errno> {
 /// ```
 pub fn getsid(pid: pid_t) -> pid_t {
     let pid = pid as usize;
+    // This function is always successful.
     syscall1(SYS_GETSID, pid).expect("getsid() failed") as pid_t
 }
 
@@ -1802,6 +1810,7 @@ pub fn getsockopt(
 /// assert!(tid > 0);
 /// ```
 pub fn gettid() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETTID).expect("getpid() failed") as pid_t
 }
 
@@ -1825,6 +1834,7 @@ pub fn gettimeofday(timeval: &mut timeval_t, tz: &mut timezone_t) -> Result<(), 
 /// assert!(uid > 0);
 /// ```
 pub fn getuid() -> uid_t {
+    // This function is always successful.
     syscall0(SYS_GETUID).expect("getuid() failed") as uid_t
 }
 

--- a/src/platform/linux-ppc64/call.rs
+++ b/src/platform/linux-ppc64/call.rs
@@ -4696,11 +4696,16 @@ pub fn rt_sigpending(set: &mut [sigset_t]) -> Result<(), Errno> {
 }
 
 /// Change the list of currently blocked signals.
-pub fn rt_sigprocmask(how: i32, set: &sigset_t, oldset: &mut sigset_t) -> Result<(), Errno> {
+pub fn rt_sigprocmask(
+    how: i32,
+    set: &sigset_t,
+    oldset: &mut sigset_t,
+    sigsetsize: size_t,
+) -> Result<(), Errno> {
     let how = how as usize;
     let set_ptr = set as *const sigset_t as usize;
     let oldset_ptr = oldset as *mut sigset_t as usize;
-    syscall3(SYS_RT_SIGPROCMASK, how, set_ptr, oldset_ptr).map(drop)
+    syscall4(SYS_RT_SIGPROCMASK, how, set_ptr, oldset_ptr, sigsetsize).map(drop)
 }
 
 /// Queue a signal and data.

--- a/src/platform/linux-s390x/call.rs
+++ b/src/platform/linux-s390x/call.rs
@@ -118,6 +118,7 @@ pub fn afs_syscall() {
 /// ```
 pub fn alarm(seconds: u32) -> u32 {
     let seconds = seconds as usize;
+    // This function is always successful.
     syscall1(SYS_ALARM, seconds).expect("alarm() failed") as u32
 }
 
@@ -1488,6 +1489,7 @@ pub fn getdents64(fd: i32, dirp: usize, count: size_t) -> Result<ssize_t, Errno>
 /// assert!(egid > 0);
 /// ```
 pub fn getegid() -> gid_t {
+    // This function is always successful.
     syscall0(SYS_GETEGID).expect("getegid() failed") as gid_t
 }
 
@@ -1497,6 +1499,7 @@ pub fn getegid() -> gid_t {
 /// assert!(euid > 0);
 /// ```
 pub fn geteuid() -> uid_t {
+    // This function is always successful.
     syscall0(SYS_GETEUID).expect("geteuid() failed") as uid_t
 }
 
@@ -1506,6 +1509,7 @@ pub fn geteuid() -> uid_t {
 /// assert!(gid > 0);
 /// ```
 pub fn getgid() -> gid_t {
+    // This function is always successful.
     syscall0(SYS_GETGID).expect("getgid() failed") as gid_t
 }
 
@@ -1608,6 +1612,7 @@ pub fn getpgid(pid: pid_t) -> Result<pid_t, Errno> {
 /// assert!(pgroup > 0);
 /// ```
 pub fn getpgrp() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETPGRP).expect("getpgrp() failed") as pid_t
 }
 
@@ -1617,6 +1622,7 @@ pub fn getpgrp() -> pid_t {
 /// assert!(pid > 0);
 /// ```
 pub fn getpid() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETPID).expect("getpid() failed") as pid_t
 }
 
@@ -1631,6 +1637,7 @@ pub fn getpmsg() {
 /// assert!(ppid > 0);
 /// ```
 pub fn getppid() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETPPID).expect("getppid() failed") as pid_t
 }
 
@@ -1738,6 +1745,7 @@ pub fn getrusage(who: i32, usage: &mut rusage_t) -> Result<(), Errno> {
 /// ```
 pub fn getsid(pid: pid_t) -> pid_t {
     let pid = pid as usize;
+    // This function is always successful.
     syscall1(SYS_GETSID, pid).expect("getsid() failed") as pid_t
 }
 
@@ -1783,6 +1791,7 @@ pub fn getsockopt(
 /// assert!(tid > 0);
 /// ```
 pub fn gettid() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETTID).expect("getpid() failed") as pid_t
 }
 
@@ -1806,6 +1815,7 @@ pub fn gettimeofday(timeval: &mut timeval_t, tz: &mut timezone_t) -> Result<(), 
 /// assert!(uid > 0);
 /// ```
 pub fn getuid() -> uid_t {
+    // This function is always successful.
     syscall0(SYS_GETUID).expect("getuid() failed") as uid_t
 }
 

--- a/src/platform/linux-s390x/call.rs
+++ b/src/platform/linux-s390x/call.rs
@@ -4550,11 +4550,16 @@ pub fn rt_sigpending(set: &mut [sigset_t]) -> Result<(), Errno> {
 }
 
 /// Change the list of currently blocked signals.
-pub fn rt_sigprocmask(how: i32, set: &sigset_t, oldset: &mut sigset_t) -> Result<(), Errno> {
+pub fn rt_sigprocmask(
+    how: i32,
+    set: &sigset_t,
+    oldset: &mut sigset_t,
+    sigsetsize: size_t,
+) -> Result<(), Errno> {
     let how = how as usize;
     let set_ptr = set as *const sigset_t as usize;
     let oldset_ptr = oldset as *mut sigset_t as usize;
-    syscall3(SYS_RT_SIGPROCMASK, how, set_ptr, oldset_ptr).map(drop)
+    syscall4(SYS_RT_SIGPROCMASK, how, set_ptr, oldset_ptr, sigsetsize).map(drop)
 }
 
 /// Queue a signal and data.

--- a/src/platform/linux-x86/call.rs
+++ b/src/platform/linux-x86/call.rs
@@ -118,6 +118,7 @@ pub fn afs_syscall() {
 /// ```
 pub fn alarm(seconds: u32) -> u32 {
     let seconds = seconds as usize;
+    // This function is always successful.
     syscall1(SYS_ALARM, seconds).expect("alarm() failed") as u32
 }
 
@@ -1642,6 +1643,7 @@ pub fn getdents64(fd: i32, dirp: usize, count: size_t) -> Result<ssize_t, Errno>
 /// assert!(egid > 0);
 /// ```
 pub fn getegid() -> gid_t {
+    // This function is always successful.
     syscall0(SYS_GETEGID).expect("getegid() failed") as gid_t
 }
 
@@ -1657,6 +1659,7 @@ pub fn getegid32() {
 /// assert!(euid > 0);
 /// ```
 pub fn geteuid() -> uid_t {
+    // This function is always successful.
     syscall0(SYS_GETEUID).expect("geteuid() failed") as uid_t
 }
 
@@ -1672,6 +1675,7 @@ pub fn geteuid32() {
 /// assert!(gid > 0);
 /// ```
 pub fn getgid() -> gid_t {
+    // This function is always successful.
     syscall0(SYS_GETGID).expect("getgid() failed") as gid_t
 }
 
@@ -1786,6 +1790,7 @@ pub fn getpgid(pid: pid_t) -> Result<pid_t, Errno> {
 /// assert!(pgroup > 0);
 /// ```
 pub fn getpgrp() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETPGRP).expect("getpgrp() failed") as pid_t
 }
 
@@ -1795,6 +1800,7 @@ pub fn getpgrp() -> pid_t {
 /// assert!(pid > 0);
 /// ```
 pub fn getpid() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETPID).expect("getpid() failed") as pid_t
 }
 
@@ -1809,6 +1815,7 @@ pub fn getpmsg() {
 /// assert!(ppid > 0);
 /// ```
 pub fn getppid() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETPPID).expect("getppid() failed") as pid_t
 }
 
@@ -1926,6 +1933,7 @@ pub fn getrusage(who: i32, usage: &mut rusage_t) -> Result<(), Errno> {
 /// ```
 pub fn getsid(pid: pid_t) -> pid_t {
     let pid = pid as usize;
+    // This function is always successful.
     syscall1(SYS_GETSID, pid).expect("getsid() failed") as pid_t
 }
 
@@ -1971,6 +1979,7 @@ pub fn getsockopt(
 /// assert!(tid > 0);
 /// ```
 pub fn gettid() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETTID).expect("getpid() failed") as pid_t
 }
 
@@ -1994,6 +2003,7 @@ pub fn gettimeofday(timeval: &mut timeval_t, tz: &mut timezone_t) -> Result<(), 
 /// assert!(uid > 0);
 /// ```
 pub fn getuid() -> uid_t {
+    // This function is always successful.
     syscall0(SYS_GETUID).expect("getuid() failed") as uid_t
 }
 

--- a/src/platform/linux-x86/call.rs
+++ b/src/platform/linux-x86/call.rs
@@ -4885,11 +4885,16 @@ pub fn rt_sigpending(set: &mut [sigset_t]) -> Result<(), Errno> {
 }
 
 /// Change the list of currently blocked signals.
-pub fn rt_sigprocmask(how: i32, set: &sigset_t, oldset: &mut sigset_t) -> Result<(), Errno> {
+pub fn rt_sigprocmask(
+    how: i32,
+    set: &sigset_t,
+    oldset: &mut sigset_t,
+    sigsetsize: size_t,
+) -> Result<(), Errno> {
     let how = how as usize;
     let set_ptr = set as *const sigset_t as usize;
     let oldset_ptr = oldset as *mut sigset_t as usize;
-    syscall3(SYS_RT_SIGPROCMASK, how, set_ptr, oldset_ptr).map(drop)
+    syscall4(SYS_RT_SIGPROCMASK, how, set_ptr, oldset_ptr, sigsetsize).map(drop)
 }
 
 /// Queue a signal and data.

--- a/src/platform/linux-x86_64/call.rs
+++ b/src/platform/linux-x86_64/call.rs
@@ -4530,11 +4530,16 @@ pub fn rt_sigpending(set: &mut [sigset_t]) -> Result<(), Errno> {
 }
 
 /// Change the list of currently blocked signals.
-pub fn rt_sigprocmask(how: i32, set: &sigset_t, oldset: &mut sigset_t) -> Result<(), Errno> {
+pub fn rt_sigprocmask(
+    how: i32,
+    set: &sigset_t,
+    oldset: &mut sigset_t,
+    sigsetsize: size_t,
+) -> Result<(), Errno> {
     let how = how as usize;
     let set_ptr = set as *const sigset_t as usize;
     let oldset_ptr = oldset as *mut sigset_t as usize;
-    syscall3(SYS_RT_SIGPROCMASK, how, set_ptr, oldset_ptr).map(drop)
+    syscall4(SYS_RT_SIGPROCMASK, how, set_ptr, oldset_ptr, sigsetsize).map(drop)
 }
 
 /// Queue a signal and data.

--- a/src/platform/linux-x86_64/call.rs
+++ b/src/platform/linux-x86_64/call.rs
@@ -125,6 +125,7 @@ pub fn afs_syscall() {
 /// ```
 pub fn alarm(seconds: u32) -> u32 {
     let seconds = seconds as usize;
+    // This function is always successful.
     syscall1(SYS_ALARM, seconds).expect("alarm() failed") as u32
 }
 
@@ -1481,6 +1482,7 @@ pub fn getdents64(fd: i32, dirp: usize, count: size_t) -> Result<ssize_t, Errno>
 /// assert!(egid > 0);
 /// ```
 pub fn getegid() -> gid_t {
+    // This function is always successful.
     syscall0(SYS_GETEGID).expect("getegid() failed") as gid_t
 }
 
@@ -1490,6 +1492,7 @@ pub fn getegid() -> gid_t {
 /// assert!(euid > 0);
 /// ```
 pub fn geteuid() -> uid_t {
+    // This function is always successful.
     syscall0(SYS_GETEUID).expect("geteuid() failed") as uid_t
 }
 
@@ -1499,6 +1502,7 @@ pub fn geteuid() -> uid_t {
 /// assert!(gid > 0);
 /// ```
 pub fn getgid() -> gid_t {
+    // This function is always successful.
     syscall0(SYS_GETGID).expect("getgid() failed") as gid_t
 }
 
@@ -1601,6 +1605,7 @@ pub fn getpgid(pid: pid_t) -> Result<pid_t, Errno> {
 /// assert!(pgroup > 0);
 /// ```
 pub fn getpgrp() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETPGRP).expect("getpgrp() failed") as pid_t
 }
 
@@ -1610,6 +1615,7 @@ pub fn getpgrp() -> pid_t {
 /// assert!(pid > 0);
 /// ```
 pub fn getpid() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETPID).expect("getpid() failed") as pid_t
 }
 
@@ -1624,6 +1630,7 @@ pub fn getpmsg() {
 /// assert!(ppid > 0);
 /// ```
 pub fn getppid() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETPPID).expect("getppid() failed") as pid_t
 }
 
@@ -1731,6 +1738,7 @@ pub fn getrusage(who: i32, usage: &mut rusage_t) -> Result<(), Errno> {
 /// ```
 pub fn getsid(pid: pid_t) -> pid_t {
     let pid = pid as usize;
+    // This function is always successful.
     syscall1(SYS_GETSID, pid).expect("getsid() failed") as pid_t
 }
 
@@ -1776,6 +1784,7 @@ pub fn getsockopt(
 /// assert!(tid > 0);
 /// ```
 pub fn gettid() -> pid_t {
+    // This function is always successful.
     syscall0(SYS_GETTID).expect("getpid() failed") as pid_t
 }
 
@@ -1799,6 +1808,7 @@ pub fn gettimeofday(timeval: &mut timeval_t, tz: &mut timezone_t) -> Result<(), 
 /// assert!(uid > 0);
 /// ```
 pub fn getuid() -> uid_t {
+    // This function is always successful.
     syscall0(SYS_GETUID).expect("getuid() failed") as uid_t
 }
 


### PR DESCRIPTION
The call was missing sigsetsize parameter. See: https://man7.org/linux/man-pages/man2/sigprocmask.2.html