### PR TITLE
Fix paramter order of kexec_file_load

### DIFF
--- a/src/linux_call.rs
+++ b/src/linux_call.rs
@@ -6137,8 +6137,8 @@ pub fn kexec_file_load<P: AsRef<Path>>(
         SYS_KEXEC_FILE_LOAD,
         kernel_fd,
         initrd_fd,
-        cmdline_ptr,
         cmdline_len,
+        cmdline_ptr,
         flags,
     )
     .map(drop)

--- a/src/platform/linux-aarch64/call.rs
+++ b/src/platform/linux-aarch64/call.rs
@@ -1993,8 +1993,8 @@ pub fn kexec_file_load<P: AsRef<Path>>(
         SYS_KEXEC_FILE_LOAD,
         kernel_fd,
         initrd_fd,
-        cmdline_ptr,
         cmdline_len,
+        cmdline_ptr,
         flags,
     )
     .map(drop)

--- a/src/platform/linux-arm/call.rs
+++ b/src/platform/linux-arm/call.rs
@@ -2422,8 +2422,8 @@ pub fn kexec_file_load<P: AsRef<Path>>(
         SYS_KEXEC_FILE_LOAD,
         kernel_fd,
         initrd_fd,
-        cmdline_ptr,
         cmdline_len,
+        cmdline_ptr,
         flags,
     )
     .map(drop)

--- a/src/platform/linux-ppc64/call.rs
+++ b/src/platform/linux-ppc64/call.rs
@@ -2395,8 +2395,8 @@ pub fn kexec_file_load<P: AsRef<Path>>(
         SYS_KEXEC_FILE_LOAD,
         kernel_fd,
         initrd_fd,
-        cmdline_ptr,
         cmdline_len,
+        cmdline_ptr,
         flags,
     )
     .map(drop)

--- a/src/platform/linux-s390x/call.rs
+++ b/src/platform/linux-s390x/call.rs
@@ -2353,8 +2353,8 @@ pub fn kexec_file_load<P: AsRef<Path>>(
         SYS_KEXEC_FILE_LOAD,
         kernel_fd,
         initrd_fd,
-        cmdline_ptr,
         cmdline_len,
+        cmdline_ptr,
         flags,
     )
     .map(drop)

--- a/src/platform/linux-x86_64/call.rs
+++ b/src/platform/linux-x86_64/call.rs
@@ -2340,8 +2340,8 @@ pub fn kexec_file_load<P: AsRef<Path>>(
         SYS_KEXEC_FILE_LOAD,
         kernel_fd,
         initrd_fd,
-        cmdline_ptr,
         cmdline_len,
+        cmdline_ptr,
         flags,
     )
     .map(drop)


### PR DESCRIPTION
The order of parameters are wrong according to man 2 kexec_file_load:

```
KEXEC_LOAD(2)                     Linux Programmer's Manual                    KEXEC_LOAD(2)

NAME
kexec_load, kexec_file_load - load a new kernel for later execution

SYNOPSIS
#include <linux/kexec.h>

long kexec_load(unsigned long entry, unsigned long nr_segments,
struct kexec_segment *segments, unsigned long flags);

long kexec_file_load(int kernel_fd, int initrd_fd,
unsigned long cmdline_len, const char *cmdline,
unsigned long flags);

Note: There are no glibc wrappers for these system calls; see NOTES.

```