### PR TITLE
Fix build with --no-default-features and test this in github actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,3 +44,5 @@ jobs:
     - run: cargo build --verbose
     - run: cargo doc --verbose
     - run: cargo test --verbose
+    - run: cargo build --verbose --no-default-features
+    - run: cargo test --verbose --no-default-features

--- a/examples/unlink.rs
+++ b/examples/unlink.rs
@@ -3,13 +3,15 @@
 // in the LICENSE file.
 
 fn main() {
-    let path = std::path::Path::new("/tmp/nc.unlink");
-    let ret = unsafe { nc::unlinkat(nc::AT_FDCWD, path, 0) };
-    assert!(ret.is_ok());
+    if cfg!(feature = "std") {
+        let path = std::path::Path::new("/tmp/nc.unlink");
+        let ret = unsafe { nc::unlinkat(nc::AT_FDCWD, path, 0) };
+        assert!(ret.is_ok());
 
-    let path = std::path::PathBuf::from("/tmp/nc.unlink");
-    let ret = unsafe { nc::unlinkat(nc::AT_FDCWD, path, 0) };
-    assert!(ret.is_ok());
+        let path = std::path::PathBuf::from("/tmp/nc.unlink");
+        let ret = unsafe { nc::unlinkat(nc::AT_FDCWD, path, 0) };
+        assert!(ret.is_ok());
+    }
 
     let path = "/tmp/nc.unlink";
     let ret = unsafe { nc::unlinkat(nc::AT_FDCWD, path, 0) };

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,6 +6,8 @@
 #![allow(clippy::cast_sign_loss)]
 
 use alloc::collections::BTreeSet;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 
 use crate::Errno;
 


### PR DESCRIPTION
When building with `cargo build --verbose --no-default-features` I got errors about missing imports, this attempts to fix this and add github actions to ensure this command builds. :)

Thanks for making this crate.