### PR TITLE
fix(io_uring): make iOURING_OP u8

### DIFF
--- a/src/platform/linux-types/uapi/linux/io_uring.rs
+++ b/src/platform/linux-types/uapi/linux/io_uring.rs
@@ -202,7 +202,7 @@ pub const IORING_SETUP_CLAMP: u32 = 1 << 4;
 /// attach to existing wq
 pub const IORING_SETUP_ATTACH_WQ: u32 = 1 << 5;
 
-#[repr(u32)]
+#[repr(u8)]
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 pub enum IOURING_OP {
     #[default]


### PR DESCRIPTION
https://github.com/torvalds/linux/blob/1fc61ee/include/uapi/linux/io_uring.h#L31
Type of `opcode` field is `u8`.

You may also want to CamelCase the type name (and remove the `IORING_OP` prefix in enum variants).