### PR TITLE
Don't clobber `r7` on 32-bit ARM

### DIFF
--- a/src/syscalls/syscall_arm.rs
+++ b/src/syscalls/syscall_arm.rs
@@ -15,9 +15,8 @@ pub unsafe fn syscall0(n: Sysno) -> Result<usize, Errno> {
     let ret: usize;
     unsafe {
         asm!(
-            "mov r7, {n}",
             "swi 0",
-             n = in(reg) n,
+             in("r7") n,
              lateout("r0") ret,
         );
     }
@@ -29,9 +28,8 @@ pub unsafe fn syscall1(n: Sysno, a1: usize) -> Result<usize, Errno> {
     let ret: usize;
     unsafe {
         asm!(
-            "mov r7, {n}",
             "swi 0",
-             n = in(reg) n,
+             in("r7") n,
              in("r0") a1,
              lateout("r0") ret,
         );
@@ -44,9 +42,8 @@ pub unsafe fn syscall2(n: Sysno, a1: usize, a2: usize) -> Result<usize, Errno> {
     let ret: usize;
     unsafe {
         asm!(
-            "mov r7, {n}",
             "swi 0",
-             n = in(reg) n,
+             in("r7") n,
              in("r0") a1,
              in("r1") a2,
              lateout("r0") ret,
@@ -60,9 +57,8 @@ pub unsafe fn syscall3(n: Sysno, a1: usize, a2: usize, a3: usize) -> Result<usiz
     let ret: usize;
     unsafe {
         asm!(
-            "mov r7, {n}",
             "swi 0",
-             n = in(reg) n,
+             in("r7") n,
              in("r0") a1,
              in("r1") a2,
              in("r2") a3,
@@ -83,9 +79,8 @@ pub unsafe fn syscall4(
     let ret: usize;
     unsafe {
         asm!(
-            "mov r7, {n}",
             "swi 0",
-             n = in(reg) n,
+             in("r7") n,
              in("r0") a1,
              in("r1") a2,
              in("r2") a3,
@@ -108,9 +103,8 @@ pub unsafe fn syscall5(
     let ret: usize;
     unsafe {
         asm!(
-            "mov r7, {n}",
             "swi 0",
-             n = in(reg) n,
+             in("r7") n,
              in("r0") a1,
              in("r1") a2,
              in("r2") a3,
@@ -135,9 +129,8 @@ pub unsafe fn syscall6(
     let ret: usize;
     unsafe {
         asm!(
-            "mov r7, {n}",
             "swi 0",
-             n = in(reg) n,
+             in("r7") n,
              in("r0") a1,
              in("r1") a2,
              in("r2") a3,


### PR DESCRIPTION
Fixes #48.

Clobbering `r7` causes undefined behavior in the form of data corruption and crashes depending on optimization flags and code structure.

There is also no need to `mov` from a register into another register when the destination register can just be specified directly.